### PR TITLE
Added support for multi-tier domains (for example, .foo.bar)

### DIFF
--- a/lib/vagrant-dnsmasq/includes/Domain.class.rb
+++ b/lib/vagrant-dnsmasq/includes/Domain.class.rb
@@ -1,6 +1,6 @@
 class Domain
 
-  MATCH = /^\.?[a-z]*$/
+  MATCH = /^(\.?[a-z0-9]+)+$/
 
   def initialize(name)
     @name = nil

--- a/test/Domain.class.spec.rb
+++ b/test/Domain.class.spec.rb
@@ -5,11 +5,23 @@ describe Domain do
   it "should return normal domain" do
     Domain.new('foobar').name.should eq('foobar')
     Domain.new('.foobar').name.should eq('foobar')
+    Domain.new('foo.bar').name.should eq('foo.bar')
+    Domain.new('.foo.bar').name.should eq('foo.bar')
+    Domain.new('foo8ar').name.should eq('foo8ar')
+    Domain.new('.foo8ar').name.should eq('foo8ar')
+    Domain.new('foo.8ar').name.should eq('foo.8ar')
+    Domain.new('.foo.8ar').name.should eq('foo.8ar')
   end
 
   it "should return dotted domain" do
     Domain.new('foobar').dotted.should eq('.foobar')
     Domain.new('.foobar').dotted.should eq('.foobar')
+    Domain.new('foo.bar').dotted.should eq('.foo.bar')
+    Domain.new('.foo.bar').dotted.should eq('.foo.bar')
+    Domain.new('foo8ar').dotted.should eq('.foo8ar')
+    Domain.new('.foo8ar').dotted.should eq('.foo8ar')
+    Domain.new('foo.8ar').dotted.should eq('.foo.8ar')
+    Domain.new('.foo.8ar').dotted.should eq('.foo.8ar')
   end
 
   it "should return valid domain if domain is passed" do
@@ -17,6 +29,18 @@ describe Domain do
     Domain.new(Domain.new('.foobar')).name.should eq('foobar')
     Domain.new(Domain.new('foobar')).dotted.should eq('.foobar')
     Domain.new(Domain.new('.foobar')).dotted.should eq('.foobar')
+    Domain.new(Domain.new('foo.bar')).name.should eq('foo.bar')
+    Domain.new(Domain.new('.foo.bar')).name.should eq('foo.bar')
+    Domain.new(Domain.new('foo.bar')).dotted.should eq('.foo.bar')
+    Domain.new(Domain.new('.foo.bar')).dotted.should eq('.foo.bar')
+    Domain.new(Domain.new('foo8ar')).name.should eq('foo8ar')
+    Domain.new(Domain.new('.foo8ar')).name.should eq('foo8ar')
+    Domain.new(Domain.new('foo8ar')).dotted.should eq('.foo8ar')
+    Domain.new(Domain.new('.foo8ar')).dotted.should eq('.foo8ar')
+    Domain.new(Domain.new('foo.8ar')).name.should eq('foo.8ar')
+    Domain.new(Domain.new('.foo.8ar')).name.should eq('foo.8ar')
+    Domain.new(Domain.new('foo.8ar')).dotted.should eq('.foo.8ar')
+    Domain.new(Domain.new('.foo.8ar')).dotted.should eq('.foo.8ar')
   end
 
   it "should make the domain lowercase" do
@@ -25,7 +49,15 @@ describe Domain do
 
   it "should fail for invalid domains" do
     expect {
-      Domain.new('foo1')
+      Domain.new('foo*')
+    }.to raise_error ArgumentError
+
+    expect {
+      Domain.new('.')
+    }.to raise_error ArgumentError
+
+    expect {
+      Domain.new('foo..bar')
     }.to raise_error ArgumentError
 
     expect {
@@ -50,7 +82,9 @@ describe Domain do
   end
 
   it "#valid? should fail for invalid domains" do
-    Domain::valid?('foo1').should eq(false)
+    Domain::valid?('foo*').should eq(false)
+    Domain::valid?('.').should eq(false)
+    Domain::valid?('foo..bar').should eq(false)
     Domain::valid?('foo_').should eq(false)
     Domain::valid?('foo.').should eq(false)
     Domain::valid?('foo-').should eq(false)


### PR DESCRIPTION
- Also allow numerals in domain.

Note: this is backwards compatible (i.e. use of .dev still valid).

Our use case:
- Each developer has their domain (e.g. *.ryan.dev) - so we need to be able to have at least two tiers in the domain.
- We want to use a TLD with a numeral to avoid conflicting with potential gTLDs (.dev is currently being bid on).
