### PR TITLE
Implemented 'bundle exec' for launching rspec tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
   - 2.0.0
-script: "rspec test/*.spec.rb"
+script: "bundle exec rspec test/*.spec.rb"


### PR DESCRIPTION
Travis CI builds seem to be failing - using "bundle exec" should fix it.
