### PR TITLE
Allow hostnames to contain hyphen.

### DIFF
--- a/lib/vagrant-dnsmasq/includes/Domain.class.rb
+++ b/lib/vagrant-dnsmasq/includes/Domain.class.rb
@@ -1,6 +1,6 @@
 class Domain
 
-  MATCH = /^(\.?[a-z0-9]+)+$/
+  MATCH = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*$/
 
   def initialize(name)
     @name = nil

--- a/test/Domain.class.spec.rb
+++ b/test/Domain.class.spec.rb
@@ -11,6 +11,7 @@ describe Domain do
     Domain.new('.foo8ar').name.should eq('foo8ar')
     Domain.new('foo.8ar').name.should eq('foo.8ar')
     Domain.new('.foo.8ar').name.should eq('foo.8ar')
+    Domain.new('foo-bar').name.should eq('foo-bar')
   end
 
   it "should return dotted domain" do
@@ -22,6 +23,7 @@ describe Domain do
     Domain.new('.foo8ar').dotted.should eq('.foo8ar')
     Domain.new('foo.8ar').dotted.should eq('.foo.8ar')
     Domain.new('.foo.8ar').dotted.should eq('.foo.8ar')
+    Domain.new('foo-bar').dotted.should eq('.foo-bar')
   end
 
   it "should return valid domain if domain is passed" do
@@ -41,6 +43,7 @@ describe Domain do
     Domain.new(Domain.new('.foo.8ar')).name.should eq('foo.8ar')
     Domain.new(Domain.new('foo.8ar')).dotted.should eq('.foo.8ar')
     Domain.new(Domain.new('.foo.8ar')).dotted.should eq('.foo.8ar')
+    Domain.new(Domain.new('foo-bar')).name.should eq('foo-bar')
   end
 
   it "should make the domain lowercase" do
@@ -69,6 +72,10 @@ describe Domain do
     }.to raise_error ArgumentError
 
     expect {
+      Domain.new('-foo')
+    }.to raise_error ArgumentError
+
+    expect {
       Domain.new('foo-')
     }.to raise_error ArgumentError
 
@@ -87,6 +94,7 @@ describe Domain do
     Domain::valid?('foo..bar').should eq(false)
     Domain::valid?('foo_').should eq(false)
     Domain::valid?('foo.').should eq(false)
+    Domain::valid?('-foo').should eq(false)
     Domain::valid?('foo-').should eq(false)
     Domain::valid?('').should eq(false)
     Domain::valid?(nil).should eq(false)


### PR DESCRIPTION
Currently hostnames cannot contain a hyphen ("-") anywhere.
This change allows domains to contain a hyphen, but not start or end with one.
See http://stackoverflow.com/q/2063213 for relevant discussion.
